### PR TITLE
fix: add vm role validation

### DIFF
--- a/roles/victoria_cluster/tasks/main.yml
+++ b/roles/victoria_cluster/tasks/main.yml
@@ -2,6 +2,13 @@
 - name: gather facts
   setup:
 
+- name: Ensure vm_role for node is set
+  assert:
+    fail_msg: "Make sure to set 'vm_role', allowed values are: 'victoria-insert', 'victoria-select', 'victoria-storage"
+    that:
+      - vm_role is defined
+      - vm_role in ['victoria-insert', 'victoria-select', 'victoria-storage']
+
 - name: Create data directory
   file:
     state: directory


### PR DESCRIPTION
Add validation against `vm_role` variable as role will fail with "Undefined variable"