### PR TITLE
fix problem with multi-line ansible_managed variable

### DIFF
--- a/roles/vmagent/templates/prometheus_scrape.yml.j2
+++ b/roles/vmagent/templates/prometheus_scrape.yml.j2
@@ -1,3 +1,3 @@
-#{{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {{ vmagent_scrape_config | to_nice_yaml }}

--- a/roles/vmagent/templates/stream_aggregation.yml.j2
+++ b/roles/vmagent/templates/stream_aggregation.yml.j2
@@ -1,3 +1,3 @@
-#{{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {{ vmagent_aggregation_config | to_nice_yaml }}

--- a/roles/vmalert/templates/alerts.yml.j2
+++ b/roles/vmalert/templates/alerts.yml.j2
@@ -1,4 +1,4 @@
-#{{ ansible_managed }}
+{{ ansible_managed | comment }}
 # Great examples of alerts - https://awesome-prometheus-alerts.grep.to/rules.html
 
 groups:


### PR DESCRIPTION
Ansible config example:

```ini
[defaults]
ansible_managed = !!!!!!!!!!!!!!!
    This file was generated by Ansible
    Do NOT modify this file by hand!
    !!!!!!!!!!!!!!!
```

`/opt/vic-vmagent/config.yml` before patch:

```yaml
#!!!!!!!!!!!!!!!
This file was generated by Ansible
Do NOT modify this file by hand!
!!!!!!!!!!!!!!!
...
```

`/opt/vic-vmagent/config.yml` after patch:

```yaml
#
# !!!!!!!!!!!!!!!
# This file was generated by Ansible
# Do NOT modify this file by hand!
# !!!!!!!!!!!!!!!
#
...
```