### PR TITLE
feat: allow vmagent_service_args to have multiple values for same flag

### DIFF
--- a/roles/vmagent/defaults/main.yml
+++ b/roles/vmagent/defaults/main.yml
@@ -11,6 +11,9 @@ vmagent_sd_config_dir: "{{ vmagent_config_dir }}/file_sd_configs"
 vmagent_remote_write_host: "http://localhost:8428"
 vmagent_service_args:
   "remoteWrite.url": "{{ vmagent_remote_write_host }}/api/v1/write"
+  # "remoteWrite.url":
+  # - "{{ vmagent_remote_write_host_0 }}/api/v1/write"
+  # - "{{ vmagent_remote_write_host_1 }}/api/v1/write"
   "promscrape.config": "{{ vmagent_config_dir }}/config.yml"
   "remoteWrite.tmpDataPath": /tmp/vmagent
   "remoteWrite.streamAggr.config": "{{ vmagent_config_dir }}/aggregation.yml"

--- a/roles/vmagent/templates/vmagent.service.j2
+++ b/roles/vmagent/templates/vmagent.service.j2
@@ -8,7 +8,11 @@ After=network.target
 Type=simple
 User={{ vmagent_system_user }}
 Group={{ vmagent_system_group }}
-ExecStart=/usr/local/bin/vmagent-prod {% for flag, flag_value in vmagent_service_args.items() %}--{{ flag }}={{ flag_value }} {% endfor %}
+ExecStart=/usr/local/bin/vmagent-prod {%- for flag, flag_values in vmagent_service_args.items() -%}
+{%- if flag_values | type_debug == "list" -%}
+{% for flag_value in flag_values %} --{{ flag }}={{ flag_value }} {% endfor %}
+{% else %} --{{ flag }}={{ flag_values }} {% endif %}
+{% endfor %}
 
 SyslogIdentifier=vic-vmagent
 Restart=always


### PR DESCRIPTION
This PR will make multiple remoteWrite.url possible without breaking the current configuration format.

```yaml
vmagent_service_args:
  'remoteWrite.url':
    - '{{ vmagent_remote_write_host_0 }}/api/v1/write'
    - '{{ vmagent_remote_write_host_1 }}/api/v1/write'
  'promscrape.config': '{{ vmagent_config_dir }}/config.yml'
  'remoteWrite.tmpDataPath': /tmp/vmagent
  'remoteWrite.streamAggr.config': '{{ vmagent_config_dir }}/aggregation.yml'
```