### PR TITLE
roles/vmauth: add no_log for config templating

### DIFF
--- a/roles/vmauth/tasks/configure.yml
+++ b/roles/vmauth/tasks/configure.yml
@@ -29,6 +29,7 @@
     owner: "{{ vmauth_system_user }}"
     group: "{{ vmauth_system_group }}"
     mode: 0644
+  no_log: true
   when:
     - vmauth_auth_config != ""
   notify: Restart vmauth service


### PR DESCRIPTION
Added no_log to make sure sensitive information will not be leaked in logs. See: https://github.com/VictoriaMetrics/ansible-playbooks/issues/65