### PR TITLE
Added variable vic_vm_alert_service_name for vmalert service name

### DIFF
--- a/roles/vmalert/README.md
+++ b/roles/vmalert/README.md
@@ -27,3 +27,4 @@ Installs `vmalert` as binary running with systemd
 | vic_vm_alert_service_args        | Passes options defined above to `vmalert`.                  | see [defaults.yml](./defaults/main.yml)                                                                                              |
 | vic_vm_alert_service_args        | Passes options defined above to `vmalert`.                  | see [defaults.yml](./defaults/main.yml)                                                                                              |
 | vic_vm_alert_rules               | Rules                                                       | see [defaults.yml](./defaults/main.yml)                                                                                              |
+| vic_vm_alert_service_name        | Service name that will be created by systemd or init         | see [defaults.yml](./defaults/main.yml)

--- a/roles/vmalert/defaults/main.yml
+++ b/roles/vmalert/defaults/main.yml
@@ -3,6 +3,7 @@ vic_vm_alert_version: "v1.102.0"
 vic_vm_alert_enterprise: false
 vic_vm_alert_license_key: ""
 vic_vm_alert_license_key_file: ""
+vic_vm_alert_service_name: vic-vmalert
 
 vic_vm_alert_repo_url: "https://github.com/VictoriaMetrics/VictoriaMetrics"
 vic_vm_alert_platform: "{% if vic_vm_alert_version.replace('v', '') is version('1.79.0', '>=') %}-linux{% endif %}"

--- a/roles/vmalert/handlers/main.yml
+++ b/roles/vmalert/handlers/main.yml
@@ -1,7 +1,9 @@
 # handlers file for VictoriaMetrics
 ---
-- name: Restart VMalert service
+- name: "Restart VMalert service {{ vic_vm_alert_service_name }}"
   become: true
   ansible.builtin.service:
-    name: vic-vmalert
+    name: "{{ vic_vm_alert_service_name }}"
     state: restarted
+  ignore_errors: '{{ ansible_check_mode }}'
+  listen: "Restart VMalert service"

--- a/roles/vmalert/tasks/configure.yml
+++ b/roles/vmalert/tasks/configure.yml
@@ -5,13 +5,13 @@
   - name: "Systemd | Copy VMalert systemd unit file"
     ansible.builtin.template:
       src: systemd-service.j2
-      dest: /etc/systemd/system/vic-vmalert.service
+      dest: "/etc/systemd/system/{{ vic_vm_alert_service_name }}.service"
       owner: root
       group: root
       mode: 0644
     register: config_template
     notify: Restart VMalert service
-    no_log: True
+ #   no_log: True
 
   - name: "Systemd | daemon-reload VMalert service" # noqa: no-handler
     become: true
@@ -22,25 +22,26 @@
   - name: Ensure VMalert service is enabled on boot
     become: true
     ansible.builtin.systemd:
-      name: vic-vmalert
+      name: "{{ vic_vm_alert_service_name }}"
       enabled: true
+    ignore_errors: '{{ ansible_check_mode }}'
 
 - name: Configure upstart
   when: ansible_service_mgr == "upstart"
   block:
-  - name: "Upstart | Install vic-vmalert service file"
+  - name: "Upstart | Install {{ vic_vm_alert_service_name }} service file"
     ansible.builtin.template:
       src: "upstart.j2"
-      dest: "/etc/init.d/vic-vmalert"
+      dest: "/etc/init.d/{{ vic_vm_alert_service_name }}"
       mode: "0755"
       owner: root
       group: root
     notify: Restart VMalert service
     register: config_template
 
-  - name: "Upstart | Enable vic-vmalert service"
+  - name: "Upstart | Enable {{ vic_vm_alert_service_name }} service"
     ansible.builtin.service:
-      name: "vic-vmalert"
+      name: "{{ vic_vm_alert_service_name }}"
       enabled: "yes"
 
 - name: Prepare configuration dir

--- a/roles/vmalert/tasks/configure.yml
+++ b/roles/vmalert/tasks/configure.yml
@@ -11,7 +11,7 @@
       mode: 0644
     register: config_template
     notify: Restart VMalert service
- #   no_log: True
+    no_log: True
 
   - name: "Systemd | daemon-reload VMalert service" # noqa: no-handler
     become: true

--- a/roles/vmalert/tasks/configure.yml
+++ b/roles/vmalert/tasks/configure.yml
@@ -29,7 +29,7 @@
 - name: Configure upstart
   when: ansible_service_mgr == "upstart"
   block:
-  - name: "Upstart | Install {{ vic_vm_alert_service_name }} service file"
+  - name: "Upstart | Install service file {{ vic_vm_alert_service_name }}"
     ansible.builtin.template:
       src: "upstart.j2"
       dest: "/etc/init.d/{{ vic_vm_alert_service_name }}"
@@ -39,7 +39,7 @@
     notify: Restart VMalert service
     register: config_template
 
-  - name: "Upstart | Enable {{ vic_vm_alert_service_name }} service"
+  - name: "Upstart | Enable service {{ vic_vm_alert_service_name }}"
     ansible.builtin.service:
       name: "{{ vic_vm_alert_service_name }}"
       enabled: "yes"

--- a/roles/vmalert/templates/systemd-service.j2
+++ b/roles/vmalert/templates/systemd-service.j2
@@ -10,7 +10,7 @@ User={{ vic_vm_alert_system_user }}
 Group={{ vic_vm_alert_system_group }}
 ExecStart=/usr/local/bin/vmalert-prod {% for flag, flag_value in vic_vm_alert_service_args.items() %}--{{ flag }}={{ flag_value }} {% endfor %}
 
-SyslogIdentifier=vic-vmalert
+SyslogIdentifier={{ vic_vm_alert_service_name }}
 Restart=always
 
 PrivateTmp=yes

--- a/roles/vmalert/templates/upstart.j2
+++ b/roles/vmalert/templates/upstart.j2
@@ -1,21 +1,21 @@
 #! /bin/sh
 ### BEGIN INIT INFO
-# Provides:		vic-vmalert
+# Provides:		{{ vic_vm_alert_service_name }}
 # Required-Start:	$syslog
 # Required-Stop:	$syslog
 # Should-Start:		$local_fs
 # Should-Stop:		$local_fs
 # Default-Start:	2 3 4 5
 # Default-Stop:		0 1 6
-# Short-Description: vic-vmalert - VictoriaMetrics scrape agent
-# Description:		vic-vmalert - VictoriaMetrics scrape agent
+# Short-Description: {{ vic_vm_alert_service_name }} - VictoriaMetrics scrape agent
+# Description:		{{ vic_vm_alert_service_name }} - VictoriaMetrics scrape agent
 ### END INIT INFO
 
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/local/bin/VMalert-prod
 DAEMON_ARGS="{% for flag, flag_value in vic_vm_alert_service_args.items() %}--{{ flag }}={{ flag_value }} {% endfor %}"
-NAME=vic-vmalert
+NAME={{ vic_vm_alert_service_name }}
 DESC="VictoriaMetrics scrape agent"
 
 test -x $DAEMON || exit 0


### PR DESCRIPTION
Sometimes it needs to start more than one vmalert process with different configs. E.g. running a vmalert for datasource victoriametrics and the other one for datasource loki.

Variable `vic_vm_alert_service_name` give you an opportunity to configure and run several vmalert services.

Example playbook:
```yaml
---
- name: configure vmalert
  hosts: vmalert
  roles:
    - name: vmalert for victoriametrics
      role: victoriametrics.cluster.vmalert
      vars:
        vic_vm_alert_service_name: "vic-vmalert"
        vic_vm_alert_rules_config_path: /etc/vmalert/victoria.rules
        vic_vm_alert_rules: "{{ my_var_with_rules }}"
        vic_vm_alert_service_args:
          "rule": "{{ vic_vm_alert_rules_config_path }}"
          "datasource.url": "http://localhost:8428" 
          "notifier.url": "http://localhost:9093"
          "remoteWrite.url": "http://localhost:8428"
          "remoteRead.url": "http://localhost:8428"
          "httpListenAddr": "127.0.0.1:8880"

    - name: vmalert for loki
      role: victoriametrics.cluster.vmalert
      vars:
        vic_vm_alert_service_name: "vic-vmalert-loki"
        vic_vm_alert_rules_config_path: /etc/vmalert/loki.rules
        vic_vm_alert_rules: "{{ my_var_with_rules_loki }}"
        vic_vm_alert_service_args:
          "rule": "{{ vic_vm_alert_rules_config_path }}"
          "datasource.url": "http://localhost:3100/loki" 
          "notifier.url": "http://localhost:9093"
```

Also this PR fixing  the dry-run mode error, when service is not exists in systemd (first dry-run on fresh server).