### PR TITLE
all: use "no-same-owner" when unpacking binaries

### DIFF
--- a/roles/single/tasks/install.yml
+++ b/roles/single/tasks/install.yml
@@ -63,6 +63,8 @@
         src: "{{ victoriametrics_download_url }}"
         dest: /tmp/vic-single/
         remote_src: yes
+        extra_opts:
+          - --no-same-owner
       notify: Restart VictoriaMetrics service
       register: archive_downloaded
       become: no

--- a/roles/vmagent/tasks/install.yml
+++ b/roles/vmagent/tasks/install.yml
@@ -81,6 +81,8 @@
       src: "{{ vmagent_download_url }}"
       dest: /tmp
       remote_src: yes
+      extra_opts:
+      - --no-same-owner
     when:
     - not ansible_check_mode
     - not vmagent_is_installed.stat.exists or

--- a/roles/vmalert/tasks/install.yml
+++ b/roles/vmalert/tasks/install.yml
@@ -30,6 +30,8 @@
     src: "{{ vic_vm_alert_download_url }}"
     dest: /tmp
     remote_src: yes
+    extra_opts:
+      - --no-same-owner
   delegate_to: localhost
   become: no
   when:

--- a/roles/vmauth/tasks/install.yml
+++ b/roles/vmauth/tasks/install.yml
@@ -81,6 +81,8 @@
       src: "{{ vmauth_download_url }}"
       dest: /tmp
       remote_src: yes
+      extra_opts:
+      - --no-same-owner
     when:
     - not ansible_check_mode
     - not vmauth_is_installed.stat.exists or

--- a/roles/vminsert/tasks/install.yml
+++ b/roles/vminsert/tasks/install.yml
@@ -81,6 +81,8 @@
       src: "{{ vminsert_download_url }}"
       dest: /tmp
       remote_src: yes
+      extra_opts:
+      - --no-same-owner
     when:
     - not ansible_check_mode
     - not vminsert_is_installed.stat.exists or

--- a/roles/vmselect/tasks/install.yml
+++ b/roles/vmselect/tasks/install.yml
@@ -81,6 +81,8 @@
       src: "{{ vmselect_download_url }}"
       dest: /tmp
       remote_src: yes
+      extra_opts:
+      - --no-same-owner
     when:
     - not ansible_check_mode
     - not vmselect_is_installed.stat.exists or

--- a/roles/vmstorage/tasks/install.yml
+++ b/roles/vmstorage/tasks/install.yml
@@ -81,6 +81,8 @@
       src: "{{ vmstorage_download_url }}"
       dest: /tmp
       remote_src: yes
+      extra_opts:
+      - --no-same-owner
     when:
     - not ansible_check_mode
     - not vmstorage_is_installed.stat.exists or


### PR DESCRIPTION
This is needed in order to ignore the owner of files used to archive the files. Using owner from archive might cause issues on some systems in case ID was set to a high number. See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6788