### PR TITLE
feat(roles/vmagent): add validation to configuration files

### DIFF
--- a/roles/vmagent/tasks/configure.yml
+++ b/roles/vmagent/tasks/configure.yml
@@ -69,6 +69,7 @@
     mode: 0751
     owner: "{{ vmagent_system_user }}"
     group: "{{ vmagent_system_group }}"
+    validate: "/usr/local/bin/vmagent-prod -promscrape.config %s -dryRun"
   notify: Restart VMagent service
 
 - name: Configure stream aggregation config
@@ -78,6 +79,7 @@
     mode: 0751
     owner: "{{ vmagent_system_user }}"
     group: "{{ vmagent_system_group }}"
+    validate: "/usr/local/bin/vmagent-prod -streamAggr.config %s -dryRun"
   notify: Restart VMagent service
 
 - name: Prepare tmp data dir


### PR DESCRIPTION
Currently, when a configuration is invalid it will be deployed and the service restarted, breaking the agent. Since the configuration can be checked with the `-dryRun` flag, we can validate it before deploying.

Output of `make molecule-converge-vmagent` with invalid configuration:

```yaml
vmagent_scrape_config:
  scrape_configs:
    - job_name: localhost
      static_configs:
        - clearlynotcorrect: []
```
Error:
```
TASK [vmagent : Configure promscrape config] ***********************************
.....
 cannot unmarshal data: yaml: unmarshal errors:", "  line 8: field clearlynotcorrect not found in type promscrape.StaticConfig; pass -promscrape.config.strictParse=false command-line flag for ignoring unknown fields in yaml config"], "stdout": "", "stdout_lines": []}    
```

```yaml
vmagent_aggregation_config:
    - thisdoesntlookright: 'http_request_duration_seconds_bucket'
      interval: 5m
      without: [ instance ]
      outputs: [ total ]
```
Error:
```
....
 cannot initialize aggregators from \"/root/.ansible/tmp/ansible-tmp-1760437836.091619-5351-245839758935917/source\": cannot parse stream aggregation config: yaml: unmarshal errors:", "  line 8: field thisdoesntlookright not found in type streamaggr.Config; see https://docs.victoriametrics.com/victoriametrics/stream-aggregation/#stream-aggregation-config"]
```

With valid configurations, both tests pass successfully.