### PR TITLE
Allow usage of latest as version number

### DIFF
--- a/roles/vlsingle/tasks/preinstall.yml
+++ b/roles/vlsingle/tasks/preinstall.yml
@@ -29,9 +29,9 @@
   register: victorialogs_current_version
   when: victorialogs_is_installed.stat.exists | bool
 
-- name: Get latest Victoria Logs version via GitHub redirect
+- name: Get latest VictoriaLogs version via GitHub redirect
   ansible.builtin.uri:
-    url: "https://github.com/VictoriaMetrics/VictoriaLogs/releases/latest"
+    url: "{{ victorialogs_repo_url }}/releases/latest"
     method: HEAD
     return_content: false
     follow_redirects: false

--- a/roles/vmagent/tasks/preinstall.yml
+++ b/roles/vmagent/tasks/preinstall.yml
@@ -31,3 +31,18 @@
   check_mode: false
   register: vmagent_current_version
   when: vmagent_is_installed.stat.exists | bool
+
+- name: Get latest VMagent version via GitHub redirect
+  ansible.builtin.uri:
+    url: "{{ vmagent_repo_url }}/releases/latest"
+    method: HEAD
+    return_content: false
+    follow_redirects: false
+    status_code: 302,200
+  register: gh_redirect
+  when: vmagent_version == "latest"
+
+- name: Extract version from Location header
+  ansible.builtin.set_fact:
+    vmagent_version: "{{ (gh_redirect.location | regex_search('/releases/tag/(v[0-9].*)', '\\1'))[0] }}"
+  when: vmagent_version == "latest"

--- a/roles/vmalert/tasks/preinstall.yml
+++ b/roles/vmalert/tasks/preinstall.yml
@@ -35,3 +35,18 @@
   ansible.builtin.set_fact:
     vic_vm_alert_service_args: "{{ vic_vm_alert_service_args | combine({'rule': vic_vm_alert_rules_config_path}) }}"
   when: vic_vm_alert_rules_config_path | length > 0
+
+- name: Get latest VMalert version via GitHub redirect
+  ansible.builtin.uri:
+    url: "{{ vic_vm_alert_repo_url }}/releases/latest"
+    method: HEAD
+    return_content: false
+    follow_redirects: false
+    status_code: 302,200
+  register: gh_redirect
+  when: vic_vm_alert_version == "latest"
+
+- name: Extract version from Location header
+  ansible.builtin.set_fact:
+    vic_vm_alert_version: "{{ (gh_redirect.location | regex_search('/releases/tag/(v[0-9].*)', '\\1'))[0] }}"
+  when: vic_vm_alert_version == "latest"

--- a/roles/vmauth/tasks/preinstall.yml
+++ b/roles/vmauth/tasks/preinstall.yml
@@ -30,3 +30,18 @@
   check_mode: false
   register: vmauth_current_version
   when: vmauth_is_installed.stat.exists | bool
+
+- name: Get latest VMauth version via GitHub redirect
+  ansible.builtin.uri:
+    url: "{{ vmauth_repo_url }}/releases/latest"
+    method: HEAD
+    return_content: false
+    follow_redirects: false
+    status_code: 302,200
+  register: gh_redirect
+  when: vmauth_version == "latest"
+
+- name: Extract version from Location header
+  ansible.builtin.set_fact:
+    vmauth_version: "{{ (gh_redirect.location | regex_search('/releases/tag/(v[0-9].*)', '\\1'))[0] }}"
+  when: vmauth_version == "latest"

--- a/roles/vminsert/tasks/preinstall.yml
+++ b/roles/vminsert/tasks/preinstall.yml
@@ -30,3 +30,18 @@
   check_mode: false
   register: vminsert_current_version
   when: vminsert_is_installed.stat.exists | bool
+
+- name: Get latest VMinsert version via GitHub redirect
+  ansible.builtin.uri:
+    url: "{{ vminsert_repo_url }}/releases/latest"
+    method: HEAD
+    return_content: false
+    follow_redirects: false
+    status_code: 302,200
+  register: gh_redirect
+  when: vminsert_version == "latest"
+
+- name: Extract version from Location header
+  ansible.builtin.set_fact:
+    vminsert_version: "{{ (gh_redirect.location | regex_search('/releases/tag/(v[0-9].*)', '\\1'))[0] }}"
+  when: vminsert_version == "latest"

--- a/roles/vmselect/tasks/preinstall.yml
+++ b/roles/vmselect/tasks/preinstall.yml
@@ -30,3 +30,18 @@
   check_mode: false
   register: vmselect_current_version
   when: vmselect_is_installed.stat.exists | bool
+
+- name: Get latest VMselect version via GitHub redirect
+  ansible.builtin.uri:
+    url: "{{ vmselect_repo_url }}/releases/latest"
+    method: HEAD
+    return_content: false
+    follow_redirects: false
+    status_code: 302,200
+  register: gh_redirect
+  when: vmselect_version == "latest"
+
+- name: Extract version from Location header
+  ansible.builtin.set_fact:
+    vmselect_version: "{{ (gh_redirect.location | regex_search('/releases/tag/(v[0-9].*)', '\\1'))[0] }}"
+  when: vmselect_version == "latest"

--- a/roles/vmsingle/tasks/preinstall.yml
+++ b/roles/vmsingle/tasks/preinstall.yml
@@ -35,3 +35,18 @@
   changed_when: false
   failed_when: false
   register: crontab_which
+
+- name: Get latest VictoriaMetrics version via GitHub redirect
+  ansible.builtin.uri:
+    url: "{{ victoriametrics_repo_url }}/releases/latest"
+    method: HEAD
+    return_content: false
+    follow_redirects: false
+    status_code: 302,200
+  register: gh_redirect
+  when: victoriametrics_version == "latest"
+
+- name: Extract version from Location header
+  ansible.builtin.set_fact:
+    victoriametrics_version: "{{ (gh_redirect.location | regex_search('/releases/tag/(v[0-9].*)', '\\1'))[0] }}"
+  when: victoriametrics_version == "latest"

--- a/roles/vmstorage/tasks/preinstall.yml
+++ b/roles/vmstorage/tasks/preinstall.yml
@@ -30,3 +30,18 @@
   check_mode: false
   register: vmstorage_current_version
   when: vmstorage_is_installed.stat.exists | bool
+
+- name: Get latest VMstorage version via GitHub redirect
+  ansible.builtin.uri:
+    url: "{{ vmstorage_repo_url }}/releases/latest"
+    method: HEAD
+    return_content: false
+    follow_redirects: false
+    status_code: 302,200
+  register: gh_redirect
+  when: vmstorage_version == "latest"
+
+- name: Extract version from Location header
+  ansible.builtin.set_fact:
+    vmstorage_version: "{{ (gh_redirect.location | regex_search('/releases/tag/(v[0-9].*)', '\\1'))[0] }}"
+  when: vmstorage_version == "latest"

--- a/roles/vtsingle/tasks/preinstall.yml
+++ b/roles/vtsingle/tasks/preinstall.yml
@@ -28,3 +28,18 @@
   check_mode: false
   register: victoriatraces_current_version
   when: victoriatraces_is_installed.stat.exists | bool
+
+- name: Get latest VictoriaTraces version via GitHub redirect
+  ansible.builtin.uri:
+    url: "{{ victoriatraces_repo_url }}/releases/latest"
+    method: HEAD
+    return_content: false
+    follow_redirects: false
+    status_code: 302,200
+  register: gh_redirect
+  when: victoriatraces_version == "latest"
+
+- name: Extract version from Location header
+  ansible.builtin.set_fact:
+    victoriatraces_version: "{{ (gh_redirect.location | regex_search('/releases/tag/(v[0-9].*)', '\\1'))[0] }}"
+  when: victoriatraces_version == "latest"


### PR DESCRIPTION
As of now, it is not possible to use a playbook pointing to latest victoria log version. This PR resolve latest keyword querying github endpoint and extracting latest version number from the location of the redirected url