### PR TITLE
fix(roles/vlsingle): add whens to prevent errors in check mode

### DIFF
--- a/roles/vlsingle/handlers/main.yml
+++ b/roles/vlsingle/handlers/main.yml
@@ -5,3 +5,4 @@
   ansible.builtin.systemd:
     name: victorialogs
     state: restarted
+  when: not ansible_check_mode

--- a/roles/vlsingle/tasks/configure.yml
+++ b/roles/vlsingle/tasks/configure.yml
@@ -43,3 +43,4 @@
     name: victorialogs
     enabled: true
     state: started
+  when: not (ansible_check_mode and config_template is changed)


### PR DESCRIPTION
When running role on a fresh node in check mode - it fails on "Ensure VictoriaLogs service is enabled on boot" task and "Restart VictoriaLogs service" handler task.

This PR fixes that behavior.