### PR TITLE
fix(vmauth): remove indent

### DIFF
--- a/roles/vmauth/templates/auth.yaml.j2
+++ b/roles/vmauth/templates/auth.yaml.j2
@@ -1,3 +1,3 @@
 {{ ansible_managed | comment }}
 
-{{ vmauth_auth_config | default('') | indent(2) }}
+{{ vmauth_auth_config | default('') }}


### PR DESCRIPTION
`indent(2)` in the `vmauth` config template results in invalid YAML.
https://github.com/VictoriaMetrics/ansible-playbooks/blob/d2ee8611f86b056ddd76e23d971f2bf9e76f9656/roles/vmauth/templates/auth.yaml.j2#L3

the following ansible variable:
``` yaml
vmauth_auth_config: |-
  unauthorized_user:
    url_prefix: "http://hosta:1234"
  users:
  - username: user
    password: pass
    url_map:
    - src_paths: ["/path"]
      url_prefix: "http://hostb:5678"
```
is rendered as:
``` yaml
unauthorized_user:
    url_prefix: "http://hosta:1234"
  users:
  - username: user
    password: pass
    url_map:
    - src_paths: ["/path"]
      url_prefix: "http://hostb:5678"
```

BR, Peter