### PR TITLE
fix: properly parse systemd version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible-compat==25.8.2
-ansible-core==2.19.3
+ansible-core>=2.20.0
 ansible-lint==25.9.2
 docker==7.1.0
 molecule==25.9.0

--- a/roles/vlsingle/molecule/default/tests/test_default.yml
+++ b/roles/vlsingle/molecule/default/tests/test_default.yml
@@ -6,3 +6,11 @@ service:
 port:
   tcp:9428:
     listening: true
+
+file:
+  /etc/systemd/system/victorialogs.service:
+    exists: true
+    contains:
+      - "ProtectControlGroups=true"
+      - "ProtectKernelModules=true"
+      - "ProtectKernelTunables=yes"

--- a/roles/vlsingle/tasks/preinstall.yml
+++ b/roles/vlsingle/tasks/preinstall.yml
@@ -12,7 +12,7 @@
 
 - name: Set systemd version fact
   ansible.builtin.set_fact:
-    victorialogs_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    victorialogs_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
 
 - name: Check if VictoriaLogs is installed
   ansible.builtin.stat:

--- a/roles/vmagent/molecule/default/tests/test_default.yml
+++ b/roles/vmagent/molecule/default/tests/test_default.yml
@@ -6,3 +6,11 @@ service:
 port:
   tcp:8429:
     listening: true
+
+file:
+  /etc/systemd/system/vic-vmagent.service:
+    exists: true
+    contains:
+      - "ProtectControlGroups=true"
+      - "ProtectKernelModules=true"
+      - "ProtectKernelTunables=yes"

--- a/roles/vmagent/tasks/preinstall.yml
+++ b/roles/vmagent/tasks/preinstall.yml
@@ -14,7 +14,7 @@
 
 - name: Set systemd version fact
   ansible.builtin.set_fact:
-    vmagent_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    vmagent_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
   when: ansible_service_mgr == 'systemd'
 
 - name: Check if VMagent is installed

--- a/roles/vmalert/molecule/default/tests/test_default.yml
+++ b/roles/vmalert/molecule/default/tests/test_default.yml
@@ -6,3 +6,11 @@ service:
 port:
   tcp:9431:
     listening: true
+
+file:
+  /etc/systemd/system/vic-vmalert.service:
+    exists: true
+    contains:
+      - "ProtectControlGroups=true"
+      - "ProtectKernelModules=true"
+      - "ProtectKernelTunables=yes"

--- a/roles/vmalert/tasks/preinstall.yml
+++ b/roles/vmalert/tasks/preinstall.yml
@@ -13,7 +13,7 @@
 
 - name: Set systemd version fact
   ansible.builtin.set_fact:
-    vic_vm_alert_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    vic_vm_alert_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
   when: ansible_service_mgr == 'systemd'
 
 - name: Check if VMalert is installed

--- a/roles/vmauth/molecule/default/tests/test_default.yml
+++ b/roles/vmauth/molecule/default/tests/test_default.yml
@@ -6,3 +6,11 @@ service:
 port:
   tcp:8427:
     listening: true
+
+file:
+  /etc/systemd/system/vmauth.service:
+    exists: true
+    contains:
+      - "ProtectControlGroups=true"
+      - "ProtectKernelModules=true"
+      - "ProtectKernelTunables=yes"

--- a/roles/vmauth/tasks/preinstall.yml
+++ b/roles/vmauth/tasks/preinstall.yml
@@ -13,7 +13,7 @@
 
 - name: Set systemd version fact
   ansible.builtin.set_fact:
-    vmauth_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    vmauth_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
   when: ansible_service_mgr == 'systemd'
 
 - name: Check if vmauth is installed

--- a/roles/vminsert/molecule/default/tests/test_default.yml
+++ b/roles/vminsert/molecule/default/tests/test_default.yml
@@ -6,3 +6,11 @@ service:
 port:
   tcp:8480:
     listening: true
+
+file:
+  /etc/systemd/system/vminsert.service:
+    exists: true
+    contains:
+      - "ProtectControlGroups=true"
+      - "ProtectKernelModules=true"
+      - "ProtectKernelTunables=yes"

--- a/roles/vminsert/tasks/preinstall.yml
+++ b/roles/vminsert/tasks/preinstall.yml
@@ -13,7 +13,7 @@
 
 - name: Set systemd version fact
   ansible.builtin.set_fact:
-    vminsert_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    vminsert_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
   when: ansible_service_mgr == 'systemd'
 
 - name: Check if vminsert is installed

--- a/roles/vmselect/molecule/default/tests/test_default.yml
+++ b/roles/vmselect/molecule/default/tests/test_default.yml
@@ -2,6 +2,15 @@ service:
   "vmselect":
     enabled: true
     running: true
+
 port:
   tcp:8481:
     listening: true
+
+file:
+  /etc/systemd/system/vmselect.service:
+    exists: true
+    contains:
+      - "ProtectControlGroups=true"
+      - "ProtectKernelModules=true"
+      - "ProtectKernelTunables=yes"

--- a/roles/vmselect/tasks/preinstall.yml
+++ b/roles/vmselect/tasks/preinstall.yml
@@ -13,7 +13,7 @@
 
 - name: Set systemd version fact
   ansible.builtin.set_fact:
-    vmselect_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    vmselect_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
   when: ansible_service_mgr == 'systemd'
 
 - name: Check if vmselect is installed

--- a/roles/vmsingle/molecule/default/tests/test_default.yml
+++ b/roles/vmsingle/molecule/default/tests/test_default.yml
@@ -8,3 +8,11 @@ port:
     listening: true
   tcp:12345:
     listening: true
+
+file:
+  /etc/systemd/system/victoriametrics.service:
+    exists: true
+    contains:
+      - "ProtectControlGroups=true"
+      - "ProtectKernelModules=true"
+      - "ProtectKernelTunables=yes"

--- a/roles/vmsingle/tasks/preinstall.yml
+++ b/roles/vmsingle/tasks/preinstall.yml
@@ -12,7 +12,7 @@
 
 - name: Set systemd version fact
   ansible.builtin.set_fact:
-    victoriametrics_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    victoriametrics_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
 
 - name: Check if VictoriaMetrics is installed
   ansible.builtin.stat:

--- a/roles/vmstorage/molecule/default/tests/test_default.yml
+++ b/roles/vmstorage/molecule/default/tests/test_default.yml
@@ -2,6 +2,7 @@ service:
   "vmstorage":
     enabled: true
     running: true
+
 port:
   tcp:8482:
     listening: true
@@ -9,3 +10,11 @@ port:
     listening: true
   tcp:8401:
     listening: true
+
+file:
+  /etc/systemd/system/vmstorage.service:
+    exists: true
+    contains:
+      - "ProtectControlGroups=true"
+      - "ProtectKernelModules=true"
+      - "ProtectKernelTunables=yes"

--- a/roles/vmstorage/tasks/preinstall.yml
+++ b/roles/vmstorage/tasks/preinstall.yml
@@ -13,7 +13,7 @@
 
 - name: Set systemd version fact
   ansible.builtin.set_fact:
-    vmstorage_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    vmstorage_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
   when: ansible_service_mgr == 'systemd'
 
 - name: Check if vmstorage is installed

--- a/roles/vtsingle/molecule/default/tests/test_default.yml
+++ b/roles/vtsingle/molecule/default/tests/test_default.yml
@@ -2,6 +2,15 @@ service:
   "victoriatraces":
     enabled: true
     running: true
+
 port:
   tcp:10428:
     listening: true
+
+file:
+  /etc/systemd/system/victoriatraces.service:
+    exists: true
+    contains:
+      - "ProtectControlGroups=true"
+      - "ProtectKernelModules=true"
+      - "ProtectKernelTunables=yes"

--- a/roles/vtsingle/tasks/preinstall.yml
+++ b/roles/vtsingle/tasks/preinstall.yml
@@ -12,7 +12,7 @@
 
 - name: Set systemd version fact
   ansible.builtin.set_fact:
-    victoriatraces_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    victoriatraces_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"
 
 - name: Check if VictoriaTraces is installed
   ansible.builtin.stat:


### PR DESCRIPTION
Properly parse systemd version, looks like format of `--version` has changed and now the last token is full version with distro-specific suffix. Fix parsing by checking major version as the second token of the output.

See: https://github.com/VictoriaMetrics/ansible-playbooks/issues/113

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix systemd version detection across all roles to handle the new systemctl --version output format. Adds tests for unit hardening and bumps ansible-core to >=2.20.0.

- **Bug Fixes**
  - Parse systemd version from the second token of systemctl --version in all roles’ preinstall tasks.
  - Molecule: verify each service unit exists and includes ProtectControlGroups, ProtectKernelModules, and ProtectKernelTunables.

- **Dependencies**
  - Update ansible-core to >=2.20.0.

<sup>Written for commit 817c7298f9a12d28795e5effc1570754ceda1b6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

