### PR TITLE
cross-play set_fact persistency issue

### DIFF
--- a/roles/vmalert/defaults/main.yml
+++ b/roles/vmalert/defaults/main.yml
@@ -24,7 +24,6 @@ vic_vm_alert_service_args:
   #    - "http://host2:9093"
   #    - "http://host3:9093"
   "evaluationInterval": "{{ vic_vm_alert_evaluation_interval }}"
-  "rule": "{{ vic_vm_alert_rules_config_path if vic_vm_alert_default_rules_enabled | bool else '' }}"
 
 vic_vm_alert_max_open_files: 2097152
 

--- a/roles/vmalert/defaults/main.yml
+++ b/roles/vmalert/defaults/main.yml
@@ -24,6 +24,7 @@ vic_vm_alert_service_args:
   #    - "http://host2:9093"
   #    - "http://host3:9093"
   "evaluationInterval": "{{ vic_vm_alert_evaluation_interval }}"
+  "rule": "{{ vic_vm_alert_rules_config_path if vic_vm_alert_default_rules_enabled else '' }}"
 
 vic_vm_alert_max_open_files: 2097152
 

--- a/roles/vmalert/defaults/main.yml
+++ b/roles/vmalert/defaults/main.yml
@@ -24,7 +24,7 @@ vic_vm_alert_service_args:
   #    - "http://host2:9093"
   #    - "http://host3:9093"
   "evaluationInterval": "{{ vic_vm_alert_evaluation_interval }}"
-  "rule": "{{ vic_vm_alert_rules_config_path if vic_vm_alert_default_rules_enabled else '' }}"
+  "rule": "{{ vic_vm_alert_rules_config_path if vic_vm_alert_default_rules_enabled | bool else '' }}"
 
 vic_vm_alert_max_open_files: 2097152
 

--- a/roles/vmalert/tasks/preinstall.yml
+++ b/roles/vmalert/tasks/preinstall.yml
@@ -31,13 +31,6 @@
   register: vic_vm_alert_current_version
   when: vic_vm_alert_is_installed.stat.exists | bool
 
-- name: Add rule parameter to service config for default rules
-  ansible.builtin.set_fact:
-    vic_vm_alert_service_args: "{{ vic_vm_alert_service_args | combine({'rule': vic_vm_alert_rules_config_path}) }}"
-  when:
-    - vic_vm_alert_default_rules_enabled | bool
-    - vic_vm_alert_rules_config_path | length > 0
-
 - name: Get latest VMalert version via GitHub redirect
   ansible.builtin.uri:
     url: "{{ vic_vm_alert_repo_url }}/releases/latest"

--- a/roles/vmalert/tasks/preinstall.yml
+++ b/roles/vmalert/tasks/preinstall.yml
@@ -31,6 +31,13 @@
   register: vic_vm_alert_current_version
   when: vic_vm_alert_is_installed.stat.exists | bool
 
+- name: Add rule parameter to service config for default rules
+  ansible.builtin.set_fact:
+    _runtime_vic_vm_alert_service_args: "{{ vic_vm_alert_service_args | combine({'rule': vic_vm_alert_rules_config_path}) }}"
+  when:
+    - vic_vm_alert_default_rules_enabled | bool
+    - vic_vm_alert_rules_config_path | length > 0
+
 - name: Get latest VMalert version via GitHub redirect
   ansible.builtin.uri:
     url: "{{ vic_vm_alert_repo_url }}/releases/latest"

--- a/roles/vmalert/templates/systemd-service.j2
+++ b/roles/vmalert/templates/systemd-service.j2
@@ -11,7 +11,7 @@ Group={{ vic_vm_alert_system_group }}
 ExecStart=/usr/local/bin/vmalert-prod {%- for flag, flag_values in vic_vm_alert_service_args.items() -%}
 {%- if flag_values | type_debug == "list" -%}
 {% for flag_value in flag_values %} --{{ flag }}={{ flag_value }} {% endfor %}
-{% else %} --{{ flag }}={{ flag_values }} {% endif %}
+{% else %}{% if flag_values | length > 0 %} --{{ flag }}={{ flag_values }} {% endif %}{% endif %}
 {% endfor %}
 
 SyslogIdentifier={{ vic_vm_alert_service_name }}

--- a/roles/vmalert/templates/systemd-service.j2
+++ b/roles/vmalert/templates/systemd-service.j2
@@ -8,10 +8,10 @@ After=network.target
 Type=simple
 User={{ vic_vm_alert_system_user }}
 Group={{ vic_vm_alert_system_group }}
-ExecStart=/usr/local/bin/vmalert-prod {%- for flag, flag_values in vic_vm_alert_service_args.items() -%}
+ExecStart=/usr/local/bin/vmalert-prod {%- for flag, flag_values in _runtime_vic_vm_alert_service_args.items() -%}
 {%- if flag_values | type_debug == "list" -%}
 {% for flag_value in flag_values %} --{{ flag }}={{ flag_value }} {% endfor %}
-{% else %}{% if flag_value | length > 0 %} --{{ flag }}={{ flag_values }} {% endif %}{% endif %}
+{% else %} --{{ flag }}={{ flag_values }} {% endif %}
 {% endfor %}
 
 SyslogIdentifier={{ vic_vm_alert_service_name }}

--- a/roles/vmalert/templates/systemd-service.j2
+++ b/roles/vmalert/templates/systemd-service.j2
@@ -11,7 +11,7 @@ Group={{ vic_vm_alert_system_group }}
 ExecStart=/usr/local/bin/vmalert-prod {%- for flag, flag_values in vic_vm_alert_service_args.items() -%}
 {%- if flag_values | type_debug == "list" -%}
 {% for flag_value in flag_values %} --{{ flag }}={{ flag_value }} {% endfor %}
-{% else %}{% if flag_values | length > 0 %} --{{ flag }}={{ flag_values }} {% endif %}{% endif %}
+{% else %}{% if flag_value | length > 0 %} --{{ flag }}={{ flag_values }} {% endif %}{% endif %}
 {% endfor %}
 
 SyslogIdentifier={{ vic_vm_alert_service_name }}

--- a/roles/vmalert/templates/upstart.j2
+++ b/roles/vmalert/templates/upstart.j2
@@ -14,7 +14,7 @@
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/local/bin/VMalert-prod
-DAEMON_ARGS="{% for flag, flag_value in vic_vm_alert_service_args.items() %}--{{ flag }}={{ flag_value }} {% endfor %}"
+DAEMON_ARGS="{% for flag, flag_value in _runtime_vic_vm_alert_service_args.items() %}--{{ flag }}={{ flag_value }} {% endfor %}"
 NAME={{ vic_vm_alert_service_name }}
 DESC="VictoriaMetrics scrape agent"
 

--- a/roles/vmalert/templates/upstart.j2
+++ b/roles/vmalert/templates/upstart.j2
@@ -14,7 +14,7 @@
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/local/bin/VMalert-prod
-DAEMON_ARGS="{% for flag, flag_value in vic_vm_alert_service_args.items() %}--{{ flag }}={{ flag_value }} {% endfor %}"
+DAEMON_ARGS="{% for flag, flag_value in vic_vm_alert_service_args.items() %}{% if flag_values | length > 0 %}--{{ flag }}={{ flag_value }} {% endif %}{% endfor %}"
 NAME={{ vic_vm_alert_service_name }}
 DESC="VictoriaMetrics scrape agent"
 

--- a/roles/vmalert/templates/upstart.j2
+++ b/roles/vmalert/templates/upstart.j2
@@ -14,7 +14,7 @@
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/local/bin/VMalert-prod
-DAEMON_ARGS="{% for flag, flag_value in vic_vm_alert_service_args.items() %}{% if flag_value | length > 0 %}--{{ flag }}={{ flag_value }} {% endif %}{% endfor %}"
+DAEMON_ARGS="{% for flag, flag_value in vic_vm_alert_service_args.items() %}--{{ flag }}={{ flag_value }} {% endfor %}"
 NAME={{ vic_vm_alert_service_name }}
 DESC="VictoriaMetrics scrape agent"
 

--- a/roles/vmalert/templates/upstart.j2
+++ b/roles/vmalert/templates/upstart.j2
@@ -14,7 +14,7 @@
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/local/bin/VMalert-prod
-DAEMON_ARGS="{% for flag, flag_value in vic_vm_alert_service_args.items() %}{% if flag_values | length > 0 %}--{{ flag }}={{ flag_value }} {% endif %}{% endfor %}"
+DAEMON_ARGS="{% for flag, flag_value in vic_vm_alert_service_args.items() %}{% if flag_value | length > 0 %}--{{ flag }}={{ flag_value }} {% endif %}{% endfor %}"
 NAME={{ vic_vm_alert_service_name }}
 DESC="VictoriaMetrics scrape agent"
 


### PR DESCRIPTION
When two plays in the same playbook target the same host using the vmalert role with different configurations, the set_fact from play 1 outranks play 2's vars, causing the second instance to inherit the first play's service args.

This PR remove the set fact causing this issue. It is also a good opportunity to fix vic_vm_alert_rules_config_path default to empty so the key produces no flag, and the template should skip empty values

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-play config leakage in the `vmalert` role by scoping service args to a runtime variable so they don’t carry over between plays. The `--rule` flag is set at runtime from defaults and omitted when unset; templates avoid emitting empty flags.

- **Bug Fixes**
  - Replaced persistent `set_fact` on `vic_vm_alert_service_args` with `_runtime_vic_vm_alert_service_args` that merges `rule` when `vic_vm_alert_default_rules_enabled` is true and `vic_vm_alert_rules_config_path` is non-empty.
  - Updated systemd and upstart templates to read `_runtime_vic_vm_alert_service_args` for `ExecStart`/`DAEMON_ARGS` and skip empty values.

<sup>Written for commit 528bb7bd5697a71ab694b584a673f5737fe9a5fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/ansible-playbooks/pull/138?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

