### PR TITLE
introduce variable for vmauth service name

### DIFF
--- a/roles/vmauth/defaults/main.yml
+++ b/roles/vmauth/defaults/main.yml
@@ -11,6 +11,7 @@ vmauth_download_url: "{{ vmauth_repo_url }}/releases/download/{{ vmauth_version 
 vmauth_system_user: "victoriametrics"
 vmauth_system_group: "{{ vmauth_system_user }}"
 
+vmauth_service_name: vmauth
 vmauth_service_state: started
 vmauth_service_enabled: true
 vmauth_service_args: {}

--- a/roles/vmauth/handlers/main.yml
+++ b/roles/vmauth/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: Restart vmauth service
   ansible.builtin.systemd:
     daemon_reload: true
-    name: vmauth
+    name: "{{ vmauth_service_name }}"
     state: restarted

--- a/roles/vmauth/tasks/configure.yml
+++ b/roles/vmauth/tasks/configure.yml
@@ -2,7 +2,7 @@
 - name: "Systemd | Copy vmauth systemd unit file"
   ansible.builtin.template:
     src: vmauth.service.j2
-    dest: /etc/systemd/system/vmauth.service
+    dest: "/etc/systemd/system/{{ vmauth_service_name }}.service"
     owner: root
     group: root
     mode: "0644"
@@ -11,7 +11,7 @@
 - name: "Systemd | ensure vmauth service is enabled" # noqa: no-handler
   become: true
   ansible.builtin.systemd:
-    name: vmauth
+    name: "{{ vmauth_service_name }}"
     enabled: true
 
 - name: Prepare configuration dir


### PR DESCRIPTION
Like `vmalert`, `vmauth` is a type of service where it can make sense to run multiple differently configured copies on the same machine. This PR introduces a variable `vmauth_service_name` to configure the name of the installed service, similar to what is possible with `vmalert`.