### PR TITLE
Quote flag_values in systemd service templates

### DIFF
--- a/roles/vlagent/templates/vlagent.service.j2
+++ b/roles/vlagent/templates/vlagent.service.j2
@@ -10,8 +10,8 @@ User={{ vlagent_system_user }}
 Group={{ vlagent_system_group }}
 ExecStart=/usr/local/bin/vlagent-prod {%- for flag, flag_values in vlagent_service_args.items() -%}
 {%- if flag_values | type_debug == "list" -%}
-{% for flag_value in flag_values %} --{{ flag }}={{ flag_value }} {% endfor %}
-{% else %} --{{ flag }}={{ flag_values }} {% endif %}
+{% for flag_value in flag_values %} --{{ flag }}={{ flag_value | quote }} {% endfor %}
+{% else %} --{{ flag }}={{ flag_values | quote }} {% endif %}
 {% endfor %}
 
 SyslogIdentifier=vic-vlagent

--- a/roles/vlsingle/templates/victorialogs.service.j2
+++ b/roles/vlsingle/templates/victorialogs.service.j2
@@ -9,7 +9,7 @@ Type=simple
 LimitNOFILE={{ victorialogs_max_open_files }}
 User={{ victorialogs_system_user }}
 Group={{ victorialogs_system_group }}
-ExecStart=/usr/local/bin/victoria-logs-prod {% if (victorialogs_service_envflag_enabled | bool) %} -envflag.enable {% endif %} {% for flag, flag_value in victorialogs_service_args.items() %}-{{ flag }}={{ flag_value }} {% endfor %}
+ExecStart=/usr/local/bin/victoria-logs-prod {% if (victorialogs_service_envflag_enabled | bool) %} -envflag.enable {% endif %} {% for flag, flag_value in victorialogs_service_args.items() %}-{{ flag }}={{ flag_value | quote }} {% endfor %}
 
 SyslogIdentifier=victorialogs
 Restart=always

--- a/roles/vmagent/templates/vmagent.service.j2
+++ b/roles/vmagent/templates/vmagent.service.j2
@@ -10,8 +10,8 @@ User={{ vmagent_system_user }}
 Group={{ vmagent_system_group }}
 ExecStart=/usr/local/bin/vmagent-prod {%- for flag, flag_values in vmagent_service_args.items() -%}
 {%- if flag_values | type_debug == "list" -%}
-{% for flag_value in flag_values %} --{{ flag }}={{ flag_value }} {% endfor %}
-{% else %} --{{ flag }}={{ flag_values }} {% endif %}
+{% for flag_value in flag_values %} --{{ flag }}={{ flag_value | quote }} {% endfor %}
+{% else %} --{{ flag }}={{ flag_values | quote }} {% endif %}
 {% endfor %}
 
 SyslogIdentifier=vic-vmagent

--- a/roles/vmalert/templates/systemd-service.j2
+++ b/roles/vmalert/templates/systemd-service.j2
@@ -10,8 +10,8 @@ User={{ vic_vm_alert_system_user }}
 Group={{ vic_vm_alert_system_group }}
 ExecStart=/usr/local/bin/vmalert-prod {%- for flag, flag_values in _runtime_vic_vm_alert_service_args.items() -%}
 {%- if flag_values | type_debug == "list" -%}
-{% for flag_value in flag_values %} --{{ flag }}={{ flag_value }} {% endfor %}
-{% else %} --{{ flag }}={{ flag_values }} {% endif %}
+{% for flag_value in flag_values %} --{{ flag }}={{ flag_value | quote }} {% endfor %}
+{% else %} --{{ flag }}={{ flag_values | quote }} {% endif %}
 {% endfor %}
 
 SyslogIdentifier={{ vic_vm_alert_service_name }}

--- a/roles/vmauth/templates/vmauth.service.j2
+++ b/roles/vmauth/templates/vmauth.service.j2
@@ -9,7 +9,7 @@ User={{ vmauth_system_user }}
 Group={{ vmauth_system_group }}
 Restart=always
 EnvironmentFile={{ vmauth_config_dir }}/vmauth.conf
-ExecStart={{ vmauth_bin_dir }}/vmauth-prod -envflag.enable -auth.config={{ vmauth_config_dir }}/auth.yaml {% for flag, flag_value in vmauth_service_args.items() %}--{{ flag }}={{ flag_value }} {% endfor %}
+ExecStart={{ vmauth_bin_dir }}/vmauth-prod -envflag.enable -auth.config={{ vmauth_config_dir }}/auth.yaml {% for flag, flag_value in vmauth_service_args.items() %}--{{ flag }}={{ flag_value | quote }} {% endfor %}
 
 PrivateTmp=yes
 ProtectHome={{ vmauth_systemd_protect_home }}

--- a/roles/vmsingle/templates/victoriametrics.service.j2
+++ b/roles/vmsingle/templates/victoriametrics.service.j2
@@ -9,7 +9,7 @@ Type=simple
 LimitNOFILE={{ victoriametrics_max_open_files }}
 User={{ victoriametrics_system_user }}
 Group={{ victoriametrics_system_group }}
-ExecStart=/usr/local/bin/victoria-metrics-prod {% if (victoriametrics_service_envflag_enabled | bool) %} -envflag.enable {% endif %} {% for flag, flag_value in victoriametrics_service_args.items() %}-{{ flag }}={{ flag_value }} {% endfor %}
+ExecStart=/usr/local/bin/victoria-metrics-prod {% if (victoriametrics_service_envflag_enabled | bool) %} -envflag.enable {% endif %} {% for flag, flag_value in victoriametrics_service_args.items() %}-{{ flag }}={{ flag_value | quote }} {% endfor %}
 
 SyslogIdentifier=victoriametrics
 Restart=always

--- a/roles/vtsingle/templates/victoriatraces.service.j2
+++ b/roles/vtsingle/templates/victoriatraces.service.j2
@@ -9,7 +9,7 @@ Type=simple
 LimitNOFILE={{ victoriatraces_max_open_files }}
 User={{ victoriatraces_system_user }}
 Group={{ victoriatraces_system_group }}
-ExecStart=/usr/local/bin/victoria-traces-prod {% if (victoriatraces_service_envflag_enabled | bool) %} -envflag.enable {% endif %} {% for flag, flag_value in victoriatraces_service_args.items() %}-{{ flag }}={{ flag_value }} {% endfor %}
+ExecStart=/usr/local/bin/victoria-traces-prod {% if (victoriatraces_service_envflag_enabled | bool) %} -envflag.enable {% endif %} {% for flag, flag_value in victoriatraces_service_args.items() %}-{{ flag }}={{ flag_value | quote }} {% endfor %}
 
 SyslogIdentifier=victoriatraces
 Restart=always


### PR DESCRIPTION
I ran into issues with spaces inside `external.alert.source` templates because flag values are inserted as-is. This PR applies the [`quote` filter](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/quote_filter.html) to all `flag_values` in service templates. This should be safe, as systemd does not care about single quotes. E.g.

```
[Unit]
Description=Test service

[Service]
Environment="FOO=\"bar' baz\""
ExecStart=/usr/bin/echo '$FOO' $FOO
```

prints `bar' baz bar' baz`.

I did not touch the upstart templates as I'm not familiar with the system.